### PR TITLE
Allow writing to output-only streams

### DIFF
--- a/src/portaudio.lisp
+++ b/src/portaudio.lisp
@@ -831,9 +831,9 @@ On success NIL will be returned, or :input-overflowed if input data was discarde
 On success NIL will be returned, or :output-underflowed if additional output data was inserted after the previous call and before this call. 
 @end{return}
 "
-  (let* ((sample-format (pa-stream-input-sample-format pa-stream))
+  (let* ((sample-format (pa-stream-output-sample-format pa-stream))
          (frames (pa-stream-frames-per-buffer pa-stream))
-         (channel-count (pa-stream-input-channels pa-stream)))
+         (channel-count (pa-stream-output-channels pa-stream)))
     (when (and sample-format
                channel-count)
       (with-pointer-to-array (buffer pointer sample-format (* channel-count frames) :copy-in)


### PR DESCRIPTION
`write-stream` was checking the number of *input* channels before allowing
a write, so it would always just return immediately when you tried to write to
an output-only stream.  It should be checking the number of *output* channels
instead.  I'm pretty sure this was just a copy/paste typo.