### PR TITLE
Tweak system packaging

### DIFF
--- a/cl-portaudio.asd
+++ b/cl-portaudio.asd
@@ -1,33 +1,29 @@
-(defpackage portaudio.system
-  (:use :cl :asdf))
-
-(in-package portaudio.system)
-
-(defsystem cl-portaudio
+(defsystem "cl-portaudio"
   :licence "MIT"
   :version "1.0.0"
   :author "Michael Filonenko <filonenko.mikhail@gmail.com>"
-  :depends-on (#:cffi #:ffa)
-  :components ((:module src
+  :depends-on ("cffi" "ffa")
+  :components ((:module "src"
                 :serial t
-                :components (
-                             (:file "package")
+                :components ((:file "package")
                              (:file "portaudio"))))
-  :description "This package contains bindings to @a[http://portaudio.com/]{PortAudio}. PortAudio is a free, cross-platform, open-source, audio I/O library.")
+  :description "This package contains bindings to @a[http://portaudio.com/]{PortAudio}. PortAudio is a free, cross-platform, open-source, audio I/O library."
+  :in-order-to ((test-op (test-op "cl-portaudio/tests"))))
 
-(defsystem cl-portaudio-tests
-  :depends-on (#:cl-portaudio)
-  :components ((:module t
+(defsystem cl-portaudio/tests
+  :depends-on ("cl-portaudio")
+  :components ((:module "t"
                 :serial t
-                :components (
-                             (:file "package")
+                :components ((:file "package")
                              (:file "tests"))))
-  :description "This package contains test/examples for cl-portaudio.")
+  :description "This package contains test/examples for cl-portaudio."
+  :perform (test-op (o c)
+             (symbol-call :portaudio-tests :test-read-write-echo)
+             (symbol-call :portaudio-tests :test-read-write-converted-echo)))
 
-
-(defsystem cl-portaudio-doc
-  :depends-on (#:cl-portaudio #:atdoc)
-  :components ((:module doc
+(defsystem "cl-portaudio/doc"
+  :depends-on ("cl-portaudio" "atdoc")
+  :components ((:module "doc"
                 :serial t
                 :components ((:file "generate-doc"))))
   :description "Generate documentation using atdoc")

--- a/t/package.lisp
+++ b/t/package.lisp
@@ -1,5 +1,8 @@
 (defpackage portaudio-tests
   (:use :cl :portaudio :cffi :alexandria :ffa)
   (:nicknames #:pa-tests)
+  (:export
+   #:test-read-write-echo
+   #:test-read-write-converted-echo)
   (:documentation
    "This package contains tests/examples for PortAudio bindings."))

--- a/t/tests.lisp
+++ b/t/tests.lisp
@@ -25,7 +25,6 @@
       (with-audio-stream (astream input-parameters output-parameters :sample-rate +sample-rate+ :frames-per-buffer +frames-per-buffer+ :stream-flags (:clip-off))
         (dotimes (i (round (/ (* +seconds+ +sample-rate+) +frames-per-buffer+)))
           (write-stream astream (read-stream astream)))))))
-(export 'test-read-write-echo)
 
 (defun test-read-write-converted-echo ()
   "Record input into an array; Separate array to channels; Merge channels into array; Play last array."
@@ -37,4 +36,3 @@
                       (merge-channels-into-array astream
                                                  (separate-array-to-channels astream
                                                                              (read-stream astream))))))))
-(export 'test-read-write-converted-echo)


### PR DESCRIPTION
Follow ASDF best practices.

Don't export symbols outside of defpackage: it's an error on redefinition.