### PR TITLE
Export stop-stream to align with documentation

### DIFF
--- a/src/portaudio.lisp
+++ b/src/portaudio.lisp
@@ -854,6 +854,7 @@ On success NIL will be returned, or :output-underflowed if additional output dat
 (defun stop-stream (pa-stream)
   "Terminates audio processing. It waits until all pending audio buffers have been played before it returns."
   (raise-if-error (%stop-stream pa-stream))) 
+(export 'stop-stream)
 
 (defcstruct stream-info
   (struct-version :int)


### PR DESCRIPTION
Following the documentation, I attempted to call stop-stream only to discover it was not external in the portaudio package.  All written documentation I see implies that it should be.